### PR TITLE
[monitoring-k8s-with-telegraf-and-influxdb] Calculate the memory usage as ratio between used and available RAM

### DIFF
--- a/monitoring-k8s-with-telegraf-and-influxdb/Kubernetes_Resource_usage.json
+++ b/monitoring-k8s-with-telegraf-and-influxdb/Kubernetes_Resource_usage.json
@@ -556,7 +556,7 @@
             "type": "influxdb",
             "uid": "${DS_KUBERNETES_MONITORING (INFLUXQL)}"
           },
-          "query": "SELECT max(memory_usage_bytes)/max(memory_available_bytes) FROM kubernetes_node WHERE $timeFilter GROUP BY time($__interval), node_name",
+          "query": "SELECT max(memory_usage_bytes)/max(capacity_memory_bytes) FROM kubernetes_node WHERE $timeFilter GROUP BY time($__interval), node_name",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series"


### PR DESCRIPTION
Hi Ben,
sorry for bothering you again.
I noticed some strange metrics in the cluster and I wasn't sure that this was the intended behaviour.
However, this metric is a bit tricky: in this version, I am ignoring the OS + k8s overhead. Perhaps it would be better to calculate the utilisation as (usage / (usage + available)) instead of what I am proposing in this PR (usage / capacity).
Thanks for this nice dashboard!